### PR TITLE
Fix theme block compilation

### DIFF
--- a/syncify/process/files.ts
+++ b/syncify/process/files.ts
@@ -330,6 +330,8 @@ export function parse (path: string) {
       return section(define(Namespace.Sections, Type.Section, Kind.Liquid));
     } else if (paths.snippets.match(path)) {
       return snippet(define(Namespace.Snippets, Type.Snippet, Kind.Liquid));
+    } else if (paths.blocks.match(path)) {
+      return snippet(define(Namespace.Blocks, Type.Block, Kind.Liquid));
     } else if (paths.layout.match(path)) {
       return define(Namespace.Layout, Type.Layout, Kind.Liquid);
     } else if (paths.templates.match(path)) {
@@ -445,6 +447,8 @@ export function importFile (key: string, outputPath: string): File {
     return define(key, Namespace.Sections);
   } else if (key.startsWith('snippets/')) {
     return define(key, Namespace.Snippets);
+  } else if (key.startsWith('blocks/')) {
+    return define(key, Namespace.Blocks);
   } else if (key.startsWith('layout/')) {
     return define(key, Namespace.Layout);
   } else if (key.startsWith('customers/', 10)) {

--- a/syncify/transform/liquid.ts
+++ b/syncify/transform/liquid.ts
@@ -248,7 +248,7 @@ export async function LiquidTransform (file: File) {
 
   }
 
-  if (file.type === Type.Section) {
+  if (file.type === Type.Section || file.type === Type.Block) {
     input = await CreateSection(file);
     if (input === null) return null;
   }

--- a/syncify/transform/schema.ts
+++ b/syncify/transform/schema.ts
@@ -360,7 +360,7 @@ export function InjectBlocks (file: File, schema: SchemaBlocks[]) {
         if (prop !== 'settings') block[prop] = schema[i][prop];
       }
 
-      if (block.type === '@app') {
+      if (block.type === '@theme' || block.type === '@app') {
         blocks.push(block);
         continue;
       }


### PR DESCRIPTION
This pull request addresses two issues related to theme block functionality:

1.  **Compilation Errors:** Theme blocks were not compiling correctly when using `sy build` or `sy watch`.
2.  **Validation Errors:** Adding `{ "type": "@theme" }` to block settings was incorrectly throwing a validation error.

**Changes Made:**

* Theme blocks are now treated similarly to sections within the build process, ensuring they compile as expected. Shared schema now works on theme blocks.
* An additional condition has been implemented to correctly validate and allow the `{"type": "@theme"}` configuration in blocks without throwing errors.

**How to Test:**

1.  **Verify `sy build`:** Run `sy build --clean` on a project containing a theme block. Confirm that the build completes with theme blocks now included in the `theme/blocks/` folder.
2.  **Verify `sy watch`:** Run `sy watch --hot` after `sy build`. Make a minor modification to a theme block and save it. Confirm that `sy watch` recompiles the theme block successfully.
3.  **Verify Block Validation:** Attempt to add a block with the configuration `{ "type": "@theme" }` in the `"blocks": []` setting. Confirm that the block is added successfully and no validation error is displayed.
4. **Verify Shared Schema:** Attempt to add a block with the configuration `{ "$ref": "{{ shared_schema }}" }` in the appropriate context. Confirm that the shared schema has been successfully transformed `"$ref"` is not present.
