### PR TITLE
Fix Tailwind not recompiling on file modifications while in `sy watch`

### DIFF
--- a/packages/types/config/style.d.ts
+++ b/packages/types/config/style.d.ts
@@ -66,7 +66,19 @@ export type StyleTerse = CleanCSSOptions & {
 }
 
 export type TailwindConfig = TailwindCSSConfig & {
-  config: string[]
+  /**
+   * Legacy config setting for tailwind.config.js
+   * This is only needed for edge cases in Tailwind v4
+   *
+   * @default []
+   */
+  config: string[];
+  /**
+   * Array containing pre-glob paths for files to be watched
+   *
+   * @default []
+   */
+  watchedFiles: string[];
 }
 
 export type SASSConfig = SassOptions & {

--- a/syncify/options/settings/style.ts
+++ b/syncify/options/settings/style.ts
@@ -170,10 +170,12 @@ export async function setStyleConfig () {
 
         const tw = u.merge(override ? style.tailwind as TailwindConfig : $.processor.tailwind.config);
 
-        if (u.isArray(tw.content) && u.isEmpty(tw.content)) {
-          tw.content = [
+        if (tw && u.isUndefined(tw.watchedFiles)) tw.watchedFiles = [];
+
+        if (u.isArray(tw.watchedFiles) && u.isEmpty(tw.watchedFiles)) {
+          tw.watchedFiles = [
             join(
-              relative($.cwd, $.dirs.input),
+              $.dirs.input,
               '**',
               '*.{css,js,ts,jsx,tsx,vue,svelte,liquid,json,schema}'
             )
@@ -182,9 +184,9 @@ export async function setStyleConfig () {
 
         u.defineProperty(bundle, 'tailwind', { get () { return tw; } });
 
-        if ($.mode.watch && u.isArray(bundle.tailwind.content)) {
+        if ($.mode.watch && u.isArray(bundle.tailwind.watchedFiles)) {
 
-          const files = await glob(bundle.tailwind.content as string[]);
+          const files = await glob(bundle.tailwind.watchedFiles as string[]);
 
           if ($.processor.tailwind.map === null) {
             $.processor.tailwind.map = u.o();

--- a/syncify/options/settings/style.ts
+++ b/syncify/options/settings/style.ts
@@ -172,15 +172,50 @@ export async function setStyleConfig () {
 
         if (tw && u.isUndefined(tw.watchedFiles)) tw.watchedFiles = [];
 
-        if (u.isArray(tw.watchedFiles) && u.isEmpty(tw.watchedFiles)) {
-          tw.watchedFiles = [
-            join(
-              $.dirs.input,
-              '**',
-              '*.{css,js,ts,jsx,tsx,vue,svelte,liquid,json,schema}'
-            )
-          ];
-        }
+        if ($.mode.watch && has('watch')) {
+
+          if (!u.isArray(style.watch)) {
+            throws.typeError(
+              {
+                option: 'styles',
+                name: 'watch',
+                provided: style.watch,
+                expects: 'string[]'
+              }
+            );
+          }
+
+          for (const uri of style.watch) {
+
+            const globs = await glob(join($.dirs.input, uri));
+
+            if (globs.length === 0 && uri[0] !== '!') {
+              warn('Cannot resolve watch glob/path uri', uri);
+            }
+
+            for (const p of globs) {
+              if (await exists(p)) {
+                tw.watchedFiles.push(p);
+              } else {
+                warn('No file exists in path', p);
+              }
+            }
+
+          };
+
+        } else {
+
+          if (u.isArray(tw.watchedFiles) && u.isEmpty(tw.watchedFiles)) {
+            tw.watchedFiles.push(
+              join(
+                $.dirs.input,
+                '**',
+                '*.{css,js,ts,jsx,tsx,vue,svelte,liquid,json,schema}'
+              )
+            );
+          }
+
+        };
 
         u.defineProperty(bundle, 'tailwind', { get () { return tw; } });
 


### PR DESCRIPTION
This pull request addresses the following issues related to Tailwind.

1. **Saving of Tailwind related files:** When a file is saved, Tailwind isn't instructed to recompile with the latest changes. This forces the user to run `sy build` any time they want to align their css to their code.
2. **Watch does nothing:** Fixing the above issue created a situation where each Tailwind style would be scoped to the entire input directory/sub-directories. Adding `watch: [ ... ]` did not resolve this issue.

### Changes Made:

- Tailwind will have a default scope of files to monitor in the input directory (all files).
- If `sy watch` and `watch: [ ... ]` has valid paths, each style will be scoped to these files only.
- A file that that matches the scope of these styles is modified, Tailwind will now recompile with the latest changes.

### How to Test:

**Default Settings**
```ts
"assets/tailwind.css": {
    input: "assets/styles/tailwind.css",
    tailwind: true
}
```
This will default to include all files in it's scope and will trigger if any file if the input/source is modified.

**With Watch Settings**
```ts
"assets/blocks.css": {
    input: "assets/styles/blocks.css",
    tailwind: true,
    watch: [
        'blocks/**/*'
    ]
},
"assets/sections.css": {
    input: "assets/styles/sections.css",
    tailwind: true,
    watch: [
        'sections/**/*'
    ]
}
```
This will trigger a recompile of the Tailwind css file, if any file matches it's watch values. The watch parameter uses glob to resolve paths.

### Additional Information
- Newly added files aren't recognized by the watch function. This is normal, though I'd expect this to change in the future. For now, a new `sy watch` session needs to be run for Syncify to recognize these new files.
- Syncify can scope the files it's in charge of syncing, but the Tailwind css file is in charge of it's own source for compiling. These files can be scoped by adding following for example.

    ```css
    @import "tailwindcss" source(none);
    @source "./source/blocks";
    ```
- Tailwind now considers the use of the `tailwind.config.js` file a legacy feature. Syncify still has config settings to allow such files to work, however, we can and should point users to using `@config "../../tailwind.config.js";` in their css files. This will allow us to remove these config settings from Syncify.