### PR TITLE
Add check for .git directory and gracefully exit for project initialization

### DIFF
--- a/syncify/prompts/init.ts
+++ b/syncify/prompts/init.ts
@@ -2,7 +2,7 @@ import type { AccessScopes, LiteralString } from 'types';
 
 import { join } from 'node:path';
 
-import { rm, writeFile } from 'fs-extra';
+import { rm, writeFile, pathExists } from 'fs-extra';
 
 import * as _ from '@syncify/ansi';
 import { kill } from '@syncify/kill';
@@ -317,6 +317,10 @@ async function CreateStrap (options: { repository: string; name: string; project
 
   log.spinner('Cloning Strap', { color: _.neonGreen });
 
+  if (await pathExists(join(options.projectPath, '.git'))) {
+    return ErrorGitInitialized();
+  }
+
   await execAsync(`git clone --depth 1 ${options.repository} .`);
   await delay(); // Ensure clone has finished
   await rm(join(options.projectPath, '.git'), { recursive: true, force: true });
@@ -375,6 +379,34 @@ function ErrorFlatStructure () {
   .Line('Please refer to the documentation for more information:', _.gray)
   .NL
   .Line(`${_.CHV} ${_.underline('https://syncify.sh/usage/directory-structures')}`, _.gray)
+  .NL
+  .End($.log.group)
+  .BR
+  .toLog();
+
+  $.running ? kill.exit(0) : process.exit(0);
+
+}
+
+/**
+ * Throws when attempting to clone a repository in a project that already has git initialized
+ */
+function ErrorGitInitialized () {
+
+  _
+  .Create({ type: 'error' })
+  .Line(`GIT ALREADY INITIALIZED ${_.BAD}`, _.bold)
+  .NL
+  .Line('Attempting to clone theme into existing directory that')
+  .Line('already has git initialized.')
+  .Tree('info')
+  .NL
+  .Line('How to fix?', _.gray.bold)
+  .Line(`You will need to remove the existing  ${_.blue('.git')} folder.`, _.gray)
+  .Line(`Run '${_.red('rm -rf .git')}' in your project directory.`, _.gray)
+  .NL
+  .Line(`WARNING: This could be dangerous.`, _.bold)
+  .Line(`Ensure you're in the right directory before attempting fix!`)
   .NL
   .End($.log.group)
   .BR


### PR DESCRIPTION
This pull request addresses the following issue related to `sy init` and existing .git directories.

1. **Cloning Theme Exits Process:** If a .git folder is present during the `sy init` process, when cloning a syncify theme, the whole process will crash with an error. This error doesn't indicate what went wrong during this process.

```bash
┌─ Syncify ~ 08:58:16
│
│  v1.0.0-unstable.3
│
│  Hello Hacker 👋
│  
│  Launch a new project by selecting an open-source theme, usage example, or
│  importing a store theme, which Syncify will strap for you. API credentials can
│  be stored in a project-level .env file or within the Syncify keychain.
│
│  Project Path:     ➔  No / Yes
│  Strap Source:     ➔  themes
│  Choose Strap:     ➔  skeleton
│
│  ◒ Cloning Strap
│
│  ERROR
│
│
│  Solution?
│  This child_process error and likely unrelated to Syncify. It is unclear what has
│  caused the issue, but consult the error message or please submit an issue on
│  github repository.
│
└─ Syncify ~ 08:59:09
```

### Changes Made:

- Before the theme clone action runs, we now check if the .git folder exists in the current working directory.
- If it returns true, we throw an error and exit the process with instructions on how to fix the issue.
- If it returns false, we continue with the `git clone ...` process.

### How to Test:

1. `mkdir new-project`,
2. `cd new-project`,
3. `git init`,
4. `sy init`,
5. Select Yes to Project Path,
6. Select Themes,
7. Select skeleton

You should now see the `sy init` process exit with instructions on how to remove the .git folder in the directory.