### PR TITLE
Fix `settings_schema.json` syncing and add cancel function

### DIFF
--- a/syncify/transform/json.ts
+++ b/syncify/transform/json.ts
@@ -183,8 +183,12 @@ async function jsonCompare (file: File, local: string) {
 
       case 'stash':
 
+        log.skipped(file.key, 'stash unavailable');
+        return null;
+
       case 'cancel':
 
+        log.skipped(file.key, 'user cancelled');
         return null;
 
     }
@@ -274,13 +278,7 @@ export async function JsonTransform (file: File): Promise<string> {
 
   if ($.mode.build) return file.value;
 
-  if (file.value === null) {
-
-    log.skipped(file.key, 'user cancelled');
-
-    return;
-
-  }
+  if (file.value === null) return;
 
   if (runChecksum(file.input, file.value)) {
 

--- a/syncify/transform/json.ts
+++ b/syncify/transform/json.ts
@@ -108,6 +108,8 @@ async function jsonCompare (file: File, local: string) {
 
       if (data === null) return null;
 
+      if (data && data.change === false) return data.actual.string;
+
       json.push(data);
 
     }
@@ -155,27 +157,35 @@ async function jsonCompare (file: File, local: string) {
       ]
     });
 
-    if (action === 'open') {
+    switch (action) {
 
-      const uri = join($.dirs.temp, file.key);
+      case 'open':
 
-      await writeFile(uri, json[0].string);
+        const uri = join($.dirs.temp, file.key);
 
-      u.openInEditor(uri);
+        await writeFile(uri, json[0].string);
 
-      return null;
+        u.openInEditor(uri);
 
-    } else if (action === 'push') {
+        return null;
 
-      return json[0].string;
+      case 'push':
 
-    } else if (action === 'pull') {
+        return json[0].actual.string;
 
-      // TODO - Handle multiple-theme/store writes
+      case 'pull':
 
-      await writeFile(file.input, json[0].string);
+        // TODO - Handle multiple-theme/store writes
 
-      return null;
+        await writeFile(file.input, json[0].string);
+
+        return null;
+
+      case 'stash':
+
+      case 'cancel':
+
+        return null;
 
     }
 
@@ -263,6 +273,14 @@ export async function JsonTransform (file: File): Promise<string> {
   }
 
   if ($.mode.build) return file.value;
+
+  if (file.value === null) {
+
+    log.skipped(file.key, 'user cancelled');
+
+    return;
+
+  }
 
   if (runChecksum(file.input, file.value)) {
 


### PR DESCRIPTION
This pull request addresses the following issues related to syncing of the settings_schema.json file.

1. **Syncing Issues:** Syncing the `settings_schema.json` with the push option resulted in the file not syncing and the user being shown a sync success log.
2. **Version Mismatch:** Push option resulted in constantly seeing a version mismatch error.
3. **Cancel Syncing:** If the user was to select cancel from the options, Syncify would continue trying to sync the file. This would result in pulling in settings from the Shopify store.

### Changes Made:

- If sync is set to push, Syncify will now use the local string instead of the remote string.
- After comparing the remote and local, if they are the same, it'll attempt to resync the file, however will be skipped because it's cached.
- Refactored action settings to switch/case instead of if/else since adding the missing options.
- Stash and Cancel options now show a message and skip the sync is expected.

### How to Test:

1. Run `sy watch --hot`
2. Save a change on the `settings_schema.json` file
4. Choose any of the options and view the following result:
    1. **Open:** Opens the remote file in the editor (unchanged).
    2. **Push:** Will now push the local source changes to the remote theme.
    3. **Pull:** Will pull in changes from the remote theme to the local source.
    5. **Stash:** Will show message "stash unavailable" and skip syncing of the file.
    6. **Cancel:** Will show message "user cancelled" and skip syncing of the file.

### Additional Notes:

- `Property 'actual' does not exist on type 'ParseEvaluate<any>'` @syncify/json could have this exposed.
- The use of case/switch was chosen since we have more than 3 if/else statements. If you want this changed back, I could update the pr.
