### PR TITLE
Fix config files not updating if `package.json` was used

### DIFF
--- a/syncify/options/define/config.ts
+++ b/syncify/options/define/config.ts
@@ -76,7 +76,16 @@ export async function getConfigFile (): Promise<Config> {
 
   if ($.project.syncifyConfig !== null) {
     if (await pathExists($.project.syncifyConfig)) {
-      $.file.config = $.project.syncifyConfig;
+      if ($.project.syncifyConfig === $.file.pkg) {
+        if ($.pkg !== null && hasPath('syncify.config', $.pkg) && isEmpty($.pkg.syncify.config) === false) {
+          $.project.syncifyConfig = $.file.config = $.file.pkg;
+          return $.pkg.syncify.config;
+        } else {
+          $.file.config = null;
+        }
+      } else {
+        $.file.config = $.project.syncifyConfig;
+      }
     } else {
       $.file.config = null;
     }


### PR DESCRIPTION
This pull request fixes an issue with Syncify's config file resolution.

### The Issue

As soon as you start using config settings from within the `package.json` file, this file is saved in the cache for future actions within Syncify. This resulted in the first checks within the `getConfigFile` function to always return true when looking if the `pathExists` (because `package.json` is always there). As such the `$.file.config` always returned the `package.json` thereafter. The only way to remove this issue is to clear the cache manually.

### Expected Result

If we were to change our config from using `package.json` to `syncify.config.ts`, we should be able to without a manual cache deletion.

### Key Changes

1. Added additional checks for `package.json`

    - The additional checks determine if a `package.json` is being used in the cache and if so, checks to see if it contains config values with an early return if true.
    
    - If the `package.json` file doesn't contain any config values, then `$.file.config` will return null which will allow the rest of the function to find a valid file.
    
### Additional Notes

- I opted for a fast happy path for the `package.json` return. This does mean that this logic is duplicated from further in script, however, I feel that if the `package.json` is actually being used, then it should be checked as soon as possible. This saves continuously checking if there is a new config file while maintaining the option for `package.json` to be the fallback config.

- Once `package.json` has been used, in order to use another file, the `syncify.config` value must be empty or removed completely. Otherwise the script will continue to use this file.