### PR TITLE
FEAT: Additional Shared Schema Features and Updates

### DIFF
--- a/syncify/options/define/sections.ts
+++ b/syncify/options/define/sections.ts
@@ -121,7 +121,96 @@ async function setSchemaJson () {
 
   const { shared } = $.section;
   const warn = warnOption('Section Schema');
-  const files = [ ...$.paths.blocks.input, ...$.paths.sections.input ];
+  const files = [ ...$.paths.blocks.input, ...$.paths.sections.input, ...$.paths.config.input ];
+
+  function buildSettingsCache (file: string, settings: SchemaSettings[]) {
+
+    const refs = [];
+
+    for (const setting of settings) {
+
+      if (has('$ref', setting)) {
+
+        const [ key, prop ] = setting.$ref.split('.');
+
+        if (shared.has(key)) {
+
+          if (!$.cache.schema[shared.get(key).uri].has(file)) {
+
+            $.cache.schema[shared.get(key).uri].add(file);
+
+            if (has('settings', shared.get(key).schema[prop])) {
+
+              refs.push((shared.get(key).schema[prop] as SettingsGroup).settings);
+
+              continue;
+
+            }
+
+            refs.push(shared.get(key).schema[prop]);
+
+          }
+
+        }
+
+      }
+    }
+
+    for (const settings of refs) {
+
+      buildSettingsCache(file, settings);
+
+    }
+
+  }
+
+  function buildBlockCache (file: string, blocks: SchemaBlocks[]) {
+
+    const blockRefs: SchemaBlocks[] = [];
+    const settingsRefs = [];
+
+    for (const block of blocks) {
+
+      const blockProp = hasProp(block);
+
+      if (blockProp('$ref')) {
+
+        const [ key, prop ] = block.$ref.split('.');
+
+        if (shared.has(key)) {
+
+          if (!$.cache.schema[shared.get(key).uri].has(file)) {
+
+            $.cache.schema[shared.get(key).uri].add(file);
+
+            blockRefs.push(shared.get(key).schema[prop] as SchemaBlocks);
+
+          };
+
+        }
+
+      }
+
+      if (blockProp('settings')) {
+
+        settingsRefs.push(block.settings);
+
+      }
+    }
+
+    for (const block of blockRefs) {
+
+      buildBlockCache(file, [ block ]);
+
+    }
+
+    for (const settings of settingsRefs) {
+
+      buildSettingsCache(file, settings);
+
+    }
+
+  }
 
   for (const file of files) {
 
@@ -133,130 +222,75 @@ async function setSchemaJson () {
     $.cache.checksum[file] = hash;
 
     const data = read.toString();
-    const indices = GetSchemaIndices(data);
 
-    if (indices === null) {
-      warn('Liquid Parse Error', relative($.cwd, file));
+    if (file.includes('/config/') && file.includes('settings_schema.json')) {
+
+      const schema = parse(data);
+
+      schema.slice(1).forEach((setting: {name: string, settings: any[]}) => {
+        if (has('settings', setting) && isArray(setting.settings)) {
+
+          try {
+
+            buildSettingsCache(file, setting.settings);
+
+          } catch (e) {
+
+            if (has(file, $.cache.sections)) {
+
+              delete $.cache.sections[file];
+
+            }
+
+            warn('Config Parse Error', relative($.cwd, file));
+          }
+
+        }
+      });
+
       continue;
-    }
-
-    try {
-
-      const schema = parse<SchemaSectionTag>(data.slice(indices.begin, indices.ender));
-      const schemaProp = hasProp(schema);
-
-      function buildSettingsCache (file: string, settings: SchemaSettings[]) {
-
-        const refs = [];
-
-        for (const setting of settings) {
-
-          if (has('$ref', setting)) {
-
-            const [ key, prop ] = setting.$ref.split('.');
-
-            if (shared.has(key)) {
-
-              if (!$.cache.schema[shared.get(key).uri].has(file)) {
-
-                $.cache.schema[shared.get(key).uri].add(file);
-
-                if (has('settings', shared.get(key).schema[prop])) {
-
-                  refs.push((shared.get(key).schema[prop] as SettingsGroup).settings);
-
-                  continue;
-
-                }
-
-                refs.push(shared.get(key).schema[prop]);
-
-              }
-
-            }
-
-          }
-        }
-
-        for (const settings of refs) {
-
-          buildSettingsCache(file, settings);
-
-        }
-
-      }
-
-      function buildBlockCache (file: string, blocks: SchemaBlocks[]) {
-
-        const blockRefs: SchemaBlocks[] = [];
-        const settingsRefs = [];
-
-        for (const block of blocks) {
-
-          const blockProp = hasProp(block);
-
-          if (blockProp('$ref')) {
-
-            const [ key, prop ] = block.$ref.split('.');
-
-            if (shared.has(key)) {
-
-              if (!$.cache.schema[shared.get(key).uri].has(file)) {
-
-                $.cache.schema[shared.get(key).uri].add(file);
-
-                blockRefs.push(shared.get(key).schema[prop] as SchemaBlocks);
-
-              };
-
-            }
-
-          }
-
-          if (blockProp('settings')) {
-
-            settingsRefs.push(block.settings);
-
-          }
-        }
-
-        for (const block of blockRefs) {
-
-          buildBlockCache(file, [ block ]);
-
-        }
-
-        for (const settings of settingsRefs) {
-
-          buildSettingsCache(file, settings);
-
-        }
-
-      }
-
-      if (schemaProp('settings')) {
-
-        buildSettingsCache(file, schema.settings);
-
-      }
-
-      if (schemaProp('blocks')) {
-
-        buildBlockCache(file, schema.blocks);
-
-      }
-
-    } catch (e) {
-
-      if (has(file, $.cache.sections)) {
-
-        delete $.cache.sections[file];
-
-      }
-
-      warn('JSON Parse Error', relative($.cwd, file));
 
     }
+
+    if (file.includes('/sections/') || file.includes('/blocks/')) {
+
+      const indices = GetSchemaIndices(data);
+
+      if (indices === null) {
+        warn('Liquid Parse Error', relative($.cwd, file));
+        continue;
+      }
+
+      try {
+
+        const schema = parse<SchemaSectionTag>(data.slice(indices.begin, indices.ender));
+        const schemaProp = hasProp(schema);
+
+        if (schemaProp('settings')) {
+
+          buildSettingsCache(file, schema.settings);
+
+        }
+
+        if (schemaProp('blocks')) {
+
+          buildBlockCache(file, schema.blocks);
+
+        }
+
+      } catch (e) {
+
+        if (has(file, $.cache.sections)) {
+
+          delete $.cache.sections[file];
+
+        }
+
+        warn('JSON Parse Error', relative($.cwd, file));
+
+      }
+
+    };
 
   }
 

--- a/syncify/transform/json.ts
+++ b/syncify/transform/json.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { readFile, writeFile } from 'fs-extra';
 
-import { evaluate, ParseEvaluate, stringify } from '@syncify/json';
+import { evaluate, parse, ParseEvaluate, stringify } from '@syncify/json';
 import { timer } from '@syncify/timer';
 
 import { log } from '~cli/log';
@@ -14,6 +14,7 @@ import { themeFilesGet, themeFilesUpsertMap } from '~http/themeFiles';
 import { runChecksum } from '~process/cache';
 import { prompt } from '~prompt';
 import { theme } from '~prompts/enquirer';
+import { InjectSettings } from '~schema';
 import { tailwindParse } from '~style';
 import * as u from '~utils';
 
@@ -261,7 +262,7 @@ export async function JsonTransform (file: File): Promise<string> {
 
   if (!u.isString(read)) return;
 
-  const local = read.trim();
+  let local = read.trim();
 
   file.size = u.byteSize(local);
 
@@ -270,8 +271,34 @@ export async function JsonTransform (file: File): Promise<string> {
     return;
   }
 
+  if (file.name === 'settings_schema') {
+
+    const schemaFiles = u.values($.cache.schema);
+
+    for (const schemaFile of schemaFiles) {
+      schemaFile.delete(file.input);
+    }
+
+    const settings = parse(local);
+
+    settings.slice(1).forEach((schema: {name: string, settings: any[]}) => {
+      if (u.has('settings', schema) && u.isArray(schema.settings)) {
+        schema.settings = InjectSettings(file, schema.settings);
+      }
+    });
+
+    local = stringify(settings);
+
+  }
+
   if ($.mode.build === false && isDiff(file.type)) {
+
+    if (file.name === 'settings_schema') {
+      file.value = await jsonCompile(file, local);
+    }
+
     file.value = await jsonCompare(file, local);
+
   } else {
     file.value = await jsonCompile(file, local);
   }

--- a/syncify/transform/schema.ts
+++ b/syncify/transform/schema.ts
@@ -25,7 +25,7 @@ import { error } from '~errors';
 import { File, Type } from '~file';
 import { JsonTransform } from '~json';
 import { LiquidTransform } from '~liquid';
-import { checksum, defineProperty, has, hasProp, includes, isArray, isEmpty, isNull, isObject, isString, merge, o, omit, plur, replaceAllOccurrences, s, toArray, values } from '~utils';
+import { checksum, defineProperty, has, hasProp, isArray, isEmpty, isNull, isObject, isString, merge, o, omit, plur, replaceAllOccurrences, s, toArray, values } from '~utils';
 
 import { $, q } from '$';
 
@@ -179,6 +179,107 @@ export async function ExtractSchema (file: File): Promise<[
 }
 
 /**
+ * Properties relating to sidebar settings.
+ */
+export const sidebarProps = [
+  'content'
+];
+
+/**
+ * Properties common to all schema setting types, derived from `Schema.Common`.
+ */
+export const commonProps = [
+  'id',
+  'label',
+  'info'
+];
+
+/**
+ * Specific properties setting types, derived from `Schema.Common`.
+ */
+const headerProps: string[] = [];
+const paragraphProps = [ 'info' ];
+const checkboxProps = [ 'default' ];
+const numberProps = [ 'default', 'placeholder' ];
+const radioProps = [ 'options', 'default' ];
+const rangeProps = [ 'min', 'max', 'step', 'unit', 'default' ];
+const selectProps = [ 'options', 'default' ];
+const textProps = [ 'placeholder', 'default' ];
+const textareaProps = [ 'placeholder', 'default' ];
+const articleProps: string[] = [];
+const blogProps: string[] = [];
+const collectionProps: string[] = [];
+const imagePickerProps: string[] = [];
+const videoProps: string[] = [];
+const pageProps: string[] = [];
+const productProps: string[] = [];
+const collectionListProps = [ 'limit' ];
+const colorProps = [ 'default' ];
+const colorBackgroundProps = [ 'default' ];
+const fontPickerProps = [ 'default' ];
+const htmlProps = [ 'placeholder', 'default' ];
+const inlineRichTextProps = [ 'default' ];
+const linkListProps = [ 'default' ];
+const liquidProps = [ 'default' ];
+const productListProps = [ 'limit' ];
+const richTextProps = [ 'default' ];
+const urlProps = [ 'default' ];
+const videoUrlProps = [ 'placeholder', 'accept' ];
+
+/**
+ * A map that provides an array of all allowed property names for a given
+ * schema setting 'type'. It combines the common properties with the
+ * type-specific properties.
+ *
+ * @example
+ * const propsForRange = allowedPropsMap.range;
+ */
+export const allowedPropsMap: Record<string, string[]> = {
+  // Sidebar Inputs
+  header: [ ...sidebarProps, ...headerProps ],
+  paragraph: [ ...sidebarProps, ...paragraphProps ],
+
+  // Basic Inputs
+  checkbox: [ ...commonProps, ...checkboxProps ],
+  number: [ ...commonProps, ...numberProps ],
+  radio: [ ...commonProps, ...radioProps ],
+  range: [ ...commonProps, ...rangeProps ],
+  select: [ ...commonProps, ...selectProps ],
+  text: [ ...commonProps, ...textProps ],
+  textarea: [ ...commonProps, ...textareaProps ],
+
+  // Specialized Inputs
+  article: [ ...commonProps, ...articleProps ],
+  blog: [ ...commonProps, ...blogProps ],
+  collection: [ ...commonProps, ...collectionProps ],
+  collection_list: [ ...commonProps, ...collectionListProps ],
+  color: [ ...commonProps, ...colorProps ],
+  color_background: [ ...commonProps, ...colorBackgroundProps ],
+  font_picker: [ ...commonProps, ...fontPickerProps ],
+  html: [ ...commonProps, ...htmlProps ],
+  image_picker: [ ...commonProps, ...imagePickerProps ],
+  inline_richtext: [ ...commonProps, ...inlineRichTextProps ],
+  link_list: [ ...commonProps, ...linkListProps ],
+  liquid: [ ...commonProps, ...liquidProps ],
+  page: [ ...commonProps, ...pageProps ],
+  product: [ ...commonProps, ...productProps ],
+  product_list: [ ...commonProps, ...productListProps ],
+  richtext: [ ...commonProps, ...richTextProps ],
+  url: [ ...commonProps, ...urlProps ],
+  video: [ ...commonProps, ...videoProps ],
+  video_url: [ ...commonProps, ...videoUrlProps ]
+};
+
+/**
+ * A single array containing all unique property names available across all
+ * setting types. This is useful for validating properties or filtering
+ * out any keys that are not valid for any setting.
+ */
+export const allAvailableSettingProps = [
+  ...new Set(Object.values(allowedPropsMap).flat())
+];
+
+/**
  * Overrides Builder
  *
  * Takes the current schema item and the existing overrides,
@@ -200,13 +301,133 @@ export function OverridesBuilder (
   type: 'block' | 'setting' = 'setting'
 ) {
 
-  let allowedProps: string[] = [];
+  const allowedProps: string[] = [];
 
   if (type === 'setting') {
 
     schema = schema as SchemaSettings;
 
-    allowedProps.push('id', 'label', 'info', 'visible_if', 'default', 'options', 'placeholder', 'content');
+    switch (true) {
+      case has('$ref', schema):
+        allowedProps.push(...allAvailableSettingProps);
+        break;
+
+      case schema.type === 'header':
+        allowedProps.push(...allowedPropsMap.header);
+        break;
+
+      case schema.type === 'paragraph':
+        allowedProps.push(...allowedPropsMap.paragraph);
+        break;
+
+      case schema.type === 'checkbox':
+        allowedProps.push(...allowedPropsMap.checkbox);
+        break;
+
+      case schema.type === 'number':
+        allowedProps.push(...allowedPropsMap.number);
+        break;
+
+      case schema.type === 'radio':
+        allowedProps.push(...allowedPropsMap.radio);
+        break;
+
+      case schema.type === 'range':
+        allowedProps.push(...allowedPropsMap.range);
+        break;
+
+      case schema.type === 'select':
+        allowedProps.push(...allowedPropsMap.select);
+        break;
+
+      case schema.type === 'text':
+        allowedProps.push(...allowedPropsMap.text);
+        break;
+
+      case schema.type === 'textarea':
+        allowedProps.push(...allowedPropsMap.textarea);
+        break;
+
+      case schema.type === 'article':
+        allowedProps.push(...allowedPropsMap.article);
+        break;
+
+      case schema.type === 'blog':
+        allowedProps.push(...allowedPropsMap.blog);
+        break;
+
+      case schema.type === 'collection':
+        allowedProps.push(...allowedPropsMap.collection);
+        break;
+
+      case schema.type === 'collection_list':
+        allowedProps.push(...allowedPropsMap.collection_list);
+        break;
+
+      case schema.type === 'color':
+        allowedProps.push(...allowedPropsMap.color);
+        break;
+
+      case schema.type === 'color_background':
+        allowedProps.push(...allowedPropsMap.color_background);
+        break;
+
+      case schema.type === 'font_picker':
+        allowedProps.push(...allowedPropsMap.font_picker);
+        break;
+
+      case schema.type === 'html':
+        allowedProps.push(...allowedPropsMap.html);
+        break;
+
+      case schema.type === 'image_picker':
+        allowedProps.push(...allowedPropsMap.image_picker);
+        break;
+
+      case schema.type === 'inline_richtext':
+        allowedProps.push(...allowedPropsMap.inline_richtext);
+        break;
+
+      case schema.type === 'link_list':
+        allowedProps.push(...allowedPropsMap.link_list);
+        break;
+
+      case schema.type === 'liquid':
+        allowedProps.push(...allowedPropsMap.liquid);
+        break;
+
+      case schema.type === 'page':
+        allowedProps.push(...allowedPropsMap.page);
+        break;
+
+      case schema.type === 'product':
+        allowedProps.push(...allowedPropsMap.product);
+        break;
+
+      case schema.type === 'product_list':
+        allowedProps.push(...allowedPropsMap.product_list);
+        break;
+
+      case schema.type === 'richtext':
+        allowedProps.push(...allowedPropsMap.richtext);
+        break;
+
+      case schema.type === 'url':
+        allowedProps.push(...allowedPropsMap.url);
+        break;
+
+      case schema.type === 'video':
+        allowedProps.push(...allowedPropsMap.video);
+        break;
+
+      case schema.type === 'video_url':
+        allowedProps.push(...allowedPropsMap.video_url);
+        break;
+
+      default:
+        allowedProps.push(...commonProps);
+        break;
+    }
 
     if (has('_settings', schema)) {
       schema = merge(schema, schema._settings);
@@ -237,37 +458,12 @@ export function OverridesBuilder (
 
   for (const [ key, value ] of Object.entries(schema)) {
 
-    if (key === 'type' && value !== 'select' && value !== 'radio' && includes('options', allowedProps)) {
-      allowedProps = allowedProps.filter(function (item) {
-        return item !== 'options';
-      });
+    for (const [ key ] of Object.entries(overrides)) {
 
-      delete overrides.options;
-    }
+      if (!s(allowedProps).has(key)) {
+        delete overrides[key];
+      }
 
-    if (key === 'type' && value !== 'header' && value !== 'paragraph' && includes('content', allowedProps)) {
-      allowedProps = allowedProps.filter(function (item) {
-        return item !== 'content';
-      });
-
-      delete overrides.content;
-    }
-
-    if (key === 'type' && (value === 'header' || value === 'paragraph')) {
-      allowedProps.forEach(item => {
-        if (item !== 'content') {
-          delete overrides[item];
-        }
-      });
-
-      allowedProps.filter(function (item) {
-        return item === 'content';
-      });
-    }
-
-    if (!s(allowedProps).has(key)) {
-      delete overrides[key];
-      continue;
     }
 
     if (isNull(value) || isNull(overrides[key])) {
@@ -280,7 +476,6 @@ export function OverridesBuilder (
     }
 
     if (key === 'visible_if') {
-      // This mixes liquid in a string so could be dangerous searching for wildcard '*' values
       continue;
     }
 

--- a/syncify/transform/schema.ts
+++ b/syncify/transform/schema.ts
@@ -23,6 +23,7 @@ import { log } from '~cli/log';
 import { warn } from '~cli/warnings';
 import { error } from '~errors';
 import { File, Type } from '~file';
+import { JsonTransform } from '~json';
 import { LiquidTransform } from '~liquid';
 import { checksum, defineProperty, has, hasProp, includes, isArray, isEmpty, isNull, isObject, isString, merge, o, omit, plur, replaceAllOccurrences, s, toArray, values } from '~utils';
 
@@ -826,7 +827,20 @@ export async function SchemaTransform (file: File) {
   log.nl();
 
   for (const file of files) {
-    await LiquidTransform(file);
+    switch (file.type) {
+
+      case Type.Section:
+      case Type.Block:
+
+        await LiquidTransform(file);
+        break;
+
+      case Type.Config:
+
+        await JsonTransform(file);
+        break;
+
+    }
   }
 
   if ($.mode.hot && $.mode.bulk === false) {

--- a/syncify/transform/schema.ts
+++ b/syncify/transform/schema.ts
@@ -206,7 +206,7 @@ export function OverridesBuilder (
 
     schema = schema as SchemaSettings;
 
-    allowedProps.push('id', 'label', 'info', 'visible_if', 'default', 'options', 'placeholder');
+    allowedProps.push('id', 'label', 'info', 'visible_if', 'default', 'options', 'placeholder', 'content');
 
     if (has('_settings', schema)) {
       schema = merge(schema, schema._settings);
@@ -243,6 +243,26 @@ export function OverridesBuilder (
       });
 
       delete overrides.options;
+    }
+
+    if (key === 'type' && value !== 'header' && value !== 'paragraph' && includes('content', allowedProps)) {
+      allowedProps = allowedProps.filter(function (item) {
+        return item !== 'content';
+      });
+
+      delete overrides.content;
+    }
+
+    if (key === 'type' && (value === 'header' || value === 'paragraph')) {
+      allowedProps.forEach(item => {
+        if (item !== 'content') {
+          delete overrides[item];
+        }
+      });
+
+      allowedProps.filter(function (item) {
+        return item === 'content';
+      });
     }
 
     if (!s(allowedProps).has(key)) {


### PR DESCRIPTION
This pull request adds additional functionality to the Shared Schema system in Syncify, allowing Shared Schemas to be used within the `settings_schema.json` config file. This also includes updates to strengthen the integrity of override values within Shared Schemas with performance gains.

## Key Changes

1. **`settings_schema.json` can now use Shared Schemas**

    - Now Shared Schemas can be used in the `settings_schema.json` config file. This allows us to reuse common settings and spreads. With this addition, the Shared Schema functionality can now be utilized throughout a theme, wherever a schema setting could be used.
    
    Note: The logic for this has been included in the same file as the section/block logic. This will probably need a refactor in the future, however, the whole Shared Schema logic is almost big enough to have it's own file/s. 
    
2. **Sidebar Settings are now available in Shared Schemas**

    - While the application of this feature is very niche, we can now have a Shared Schema for sidebar settings such as header and paragraph.
    
    - These settings can have their content and info modified with overrides and are included in the wildcard logic.
    
3. **Explicit property allowance for overrides**

    - The previous iteration of the overrides had a basic list of properties that could be modified or expanded on with wildcards. This posed issues with settings that would contain properties that were not valid for that particular setting. This was exposed with the introduction of sidebar settings. For basic and specialized settings, this isn't too big of an issue, since Syncify already disposes of properties that don't match the type.
    
    - Now ANY override property values will be passed all the way to the final singleton and checked against the type. Any property that has been passed down that doesn't belong to that type will be discarded. This means the final iteration of the shared schema system, will only contain override values that are valid for it's type. In turn this give us a performance boost over the previous iteration.

    - Currently, the overrides will only process values that are of string type. This does not yet include the _new_ `visible_if` property.
    
## How To Test

1. Add a shared schema (singleton or spread) to the `settings_schema.json` and see a valid setting.

2. Create a shared schema with a paragraph type and you'll be able to override it's values using the `_settings` object.

3. Add any property to the `_settings` object. Unless it's a valid property for the type at the final node, it will be discarded.

## Additional Notes

- As mentioned above, the Shared Schema functionality has grown considerably since I first started to play with it. It's probably close to a point where we could move this logic into it's own file. This would help clear some of the confusing aspects such as having json related logic mixed with the sections logic. However, to keep pushing along with the development, it will still sit mixed in with each other. If you agree that we should look at refactoring this into it's own file, I'd really like some guidance on how you'd want this structured. In the next pass or two, I'll be able to begin that task.

- I can update the tests, however, these are really simple to check without needing to update the test files.
